### PR TITLE
Segmentation fault fix on ubuntu 18.xx

### DIFF
--- a/conformance/ISOSegmentValidator/public/src/ValidateFileIO.cpp
+++ b/conformance/ISOSegmentValidator/public/src/ValidateFileIO.cpp
@@ -52,7 +52,9 @@ UInt64 inflateOffset(UInt64 offset64)
 
 		for (index = 0; adjustedOffset >= vg.offsetEntries[index].offset; index++)
 		{
-			adjustedOffset += vg.offsetEntries[index].sizeRemoved;
+                    if(index == vg.numOffsetEntries)
+                            break;
+                    adjustedOffset += vg.offsetEntries[index].sizeRemoved;    
 		}
 	}
 
@@ -228,7 +230,7 @@ int GetFileUTFString( atomOffsetEntry *aoe, char **strP, UInt64 offset64, UInt64
 		else {
 			int ix;
 			
-			// ¥¥ clf -- The right solution is probably to generate "\uNNNN" for Unicode characters not in the range 0-0x7f. That
+			// ï¿½ï¿½ clf -- The right solution is probably to generate "\uNNNN" for Unicode characters not in the range 0-0x7f. That
 			// will require the array be 5 times as large in the worst case.
 			pASCII= noticeP; *pASCII = 0;
 			

--- a/conformance/ISOSegmentValidator/public/src/ValidateMP4.cpp
+++ b/conformance/ISOSegmentValidator/public/src/ValidateMP4.cpp
@@ -797,7 +797,7 @@ void loadOffsetInfo(char *offsetsFileName)
     vg.offsetEntries = (OffsetInfo *)malloc(vg.numOffsetEntries*sizeof(OffsetInfo));
     if(vg.offsetEntries == NULL)
     {
-        printf("Failure to allocate %d offset entries, exiting!\n",vg.numOffsetEntries);
+        printf("Failure to allocate %u offset entries, exiting!\n",vg.numOffsetEntries);
         exit(-1);
     }
 
@@ -1223,9 +1223,9 @@ char *int64todstr(UInt64 num)
 	lo = num&(0xffffffff);
 	
 	if (hi) 
-		sprintf(str,"%ld%8.8ld",hi,lo);
+		sprintf(str,"%lu%8.8lu",hi,lo);
 	else
-		sprintf(str,"%ld",lo);
+		sprintf(str,"%lu",lo);
 	return str;
 }
 
@@ -1238,9 +1238,9 @@ char *int64todstr_r(UInt64 num, char * str)
 	lo = num&(0xffffffff);
 	
 	if (hi) 
-		sprintf(str,"%ld%8.8ld",hi,lo);
+		sprintf(str,"%lu%8.8lu",hi,lo);
 	else
-		sprintf(str,"%ld",lo);
+		sprintf(str,"%lu",lo);
 	return str;
 }
 


### PR DESCRIPTION
Fixed out of bound index that caused segmentation fault as a result of infinite loop